### PR TITLE
Include end tag in parsed list of tags

### DIFF
--- a/parser.go
+++ b/parser.go
@@ -92,13 +92,13 @@ func parseEntry(scanner *bufio.Scanner) (*Entry, error) {
 		if k == "" {
 			return nil, fmt.Errorf("parse error on line %q: empty key", line)
 		}
+		e.Tags = append(e.Tags,
+			Tag{Key: k, Value: v},
+		)
 		if k == "End" {
 			foundEnd = true
 			break
 		}
-		e.Tags = append(e.Tags,
-			Tag{Key: k, Value: v},
-		)
 	}
 	if err := scanner.Err(); err != nil {
 		return nil, err


### PR DESCRIPTION
There are some cases when `varnishlog` output doesn't have to end with just `End\n` line, but it can contain `End    synth` tag. This happens for example when `varnishlog` is in `-g session` mode and it reaches the limit of uncompleted transactions. As this value is important for further analysis of what happened, we need to include the `End` tag with its value.